### PR TITLE
Unconditional `Visibility::Visible` variant

### DIFF
--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -57,9 +57,8 @@ impl Visibility {
     #[inline]
     pub fn toggle(&mut self) {
         *self = match self {
-            Visibility::Inherited => Visibility::Hidden,
+            Visibility::Inherited | Visibility::Visible => Visibility::Hidden,
             Visibility::Hidden => Visibility::Inherited,
-            Visibility::Visible => Visibility::Hidden,
         }
     }
 


### PR DESCRIPTION
PR against https://github.com/bevyengine/bevy/pull/6271

# Objective

Allow an entity to be visible when its `Parent` is Hidden.

## Solution

Add an unconditional `Visibility::Visible` variant.

remove `std::ops::Not` since that's probably confusing, add tests